### PR TITLE
support kms key alias

### DIFF
--- a/bin/keystore.rb
+++ b/bin/keystore.rb
@@ -24,7 +24,8 @@ cmd_opts =
   when 'store'
     Trollop.options do
       opt :value, 'the value to be inserted into the keystore (required for store)', required: true, type: String
-      opt :kmsid, 'the kms key id to use to encrypt the data (required for store)', required: true, type: String
+      opt :kmsid, 'the kms key id to use to encrypt the data (conditionally required for store)', type: String
+      opt :kmsalias, 'the kms key alias to use to encrypt the data(conditionally required for store)', type: String
       opt :keyname, 'the name of the key associated with the value', required: true, type: String
       opt :table, 'the name of the table to perform the lookup on', required: true, type: String
     end
@@ -39,7 +40,7 @@ cmd_opts =
 
 dynamo = Aws::DynamoDB::Client.new region: global_opts[:region]
 kms = Aws::KMS::Client.new region: global_opts[:region]
-keystore = Keystore.new dynamo: dynamo, table_name: cmd_opts[:table], kms: kms, key_id: cmd_opts[:kmsid]
+keystore = Keystore.new dynamo: dynamo, table_name: cmd_opts[:table], kms: kms, key_id: cmd_opts[:kmsid], key_alias: cmd_opts[:kmsalias]
 
 case cmd
 when 'store'

--- a/features/keystore-api.feature
+++ b/features/keystore-api.feature
@@ -5,7 +5,7 @@ Feature: Storing encrypted values with API
     Background:
         Given a region to operate in
         And a DynamoDB table to use
-        And a KMS key id to use
+        And a KMS key id or KMS key alias to use
         And test data to use
 
     Scenario: Store encrypted values

--- a/features/keystore-cli.feature
+++ b/features/keystore-cli.feature
@@ -5,7 +5,7 @@ Feature: Storing encrypted values with CLI
     Background:
         Given a region to operate in
         And a DynamoDB table to use
-        And a KMS key id to use
+        And a KMS key id or KMS key alias to use
         And test data to use
 
     @flakey

--- a/keystore.gemspec
+++ b/keystore.gemspec
@@ -4,7 +4,7 @@ spec = Gem::Specification.new do |s|
   s.name          = 'keystore'
   s.executables  << 'keystore.rb'
   s.license       = 'MIT'
-  s.version       = '0.1.3'
+  s.version       = '0.1.4'
   s.author        = [ 'Jonny Sywulak', 'Stelligent' ]
   s.email         = 'jonny@stelligent.com'
   s.homepage      = 'http://www.stelligent.com'

--- a/spec/keystore_spec.rb
+++ b/spec/keystore_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe 'Keystore' do
       mock_kms = double('AWS::KMS::Client')
       expect(mock_kms).to receive(:encrypt).and_return(KMSResult.new('dontcare'))
 
-      keystore = Keystore.new dynamo: mock_ddb, table_name: 'dontcare', kms: mock_kms, key_id: 'dontcare'
+      keystore = Keystore.new dynamo: mock_ddb, table_name: 'dontcare', kms: mock_kms, key_id: 'dontcare', key_alias: 'dontcare'
 
       begin
         keystore.store key: 'testkey', value: 'testvalue'
@@ -45,7 +45,7 @@ RSpec.describe 'Keystore' do
       mock_kms = double('AWS::KMS::Client')
       expect(mock_kms).to receive(:encrypt).with(key_id: 'dontcare', plaintext: ' ').and_return(KMSResult.new('dontcare'))
 
-      keystore = Keystore.new dynamo: mock_ddb, table_name: 'dontcare', kms: mock_kms, key_id: 'dontcare'
+      keystore = Keystore.new dynamo: mock_ddb, table_name: 'dontcare', kms: mock_kms, key_id: 'dontcare', key_alias: 'dontcare'
 
       begin
         keystore.store key: 'testkey', value: ''
@@ -64,7 +64,7 @@ RSpec.describe 'Keystore' do
       mock_kms = double('AWS::KMS::Client')
       expect(mock_kms).to receive(:encrypt).with(key_id: 'dontcare', plaintext: ' ').and_return(KMSResult.new('dontcare'))
 
-      keystore = Keystore.new dynamo: mock_ddb, table_name: 'dontcare', kms: mock_kms, key_id: 'dontcare'
+      keystore = Keystore.new dynamo: mock_ddb, table_name: 'dontcare', kms: mock_kms, key_id: 'dontcare', key_alias: 'dontcare'
 
       begin
         keystore.store key: 'testkey', value: ''


### PR DESCRIPTION
nobody likes to have to find and keep track of some GUID for the KMS key id.  This change will allow you to pass in the KMS key alias instead.  The key alias is a nice easy to remember value for us humans.
