### PR TITLE
Migrating to aws-sdk v3 and only including necessary gems

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,10 +16,4 @@ jobs:
           command: bundle exec rubocop -D
       - run:
           name: Rspec tests
-          command: bundle exec rspec --color --require spec_helper --format NyanCatFormatter spec
-workflows:
-  version: 2
-  build_and_test:
-    jobs:
-      - build
-      - test
+          command: bundle exec rspec --color --require spec_helper --format NyanCatFormatter spec\

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,3 +17,9 @@ jobs:
       - run:
           name: Rspec tests
           command: bundle exec rspec --color --require spec_helper --format NyanCatFormatter spec
+workflows:
+  version: 2
+  build_and_test:
+    jobs:
+      - build
+      - test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,19 @@
+version: 2
+jobs:
+  build:
+    docker:
+      - image: circleci/ruby:2.5.1-browsers
+    steps:
+      - checkout
+      - run:
+          name: Which bundler?
+          command: bundle -v
+      - run:
+          name: Bundle install
+          command: bundle check || bundle install
+      - run:
+          name: Rubocop lint
+          command: bundle exec rubocop -D
+      - run:
+          name: Rspec tests
+          command: bundle exec rspec --color --require spec_helper --format NyanCatFormatter spec

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -8,3 +8,7 @@ Metrics/LineLength:
   Max: 160
 Style/FrozenStringLiteralComment:
   Enabled: false
+Style/ConditionalAssignment:
+  Enabled: false
+Style/Documentation:
+  Enabled: false

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,7 +1,10 @@
 AllCops:
+  TargetRubyVersion: 2.5.1
   Exclude:
     # The gemspec file is an exception, it breaks all the rules
     - '*.gemspec'
 # you've already upped this. twice.
 Metrics/LineLength:
   Max: 160
+Style/FrozenStringLiteralComment:
+  Enabled: false

--- a/bin/keystore.rb
+++ b/bin/keystore.rb
@@ -1,16 +1,11 @@
 #!/usr/bin/env ruby
 
 require 'keystore'
-require 'aws-sdk-core'
 require 'trollop'
-begin
-  require 'aws-sdk-dynamodb'
-  require 'aws-sdk-kms'
-rescue LoadError
-  nil
-end
+require 'aws-sdk-dynamodb'
+require 'aws-sdk-kms'
 
-SUB_COMMANDS = %w(store retrieve)
+SUB_COMMANDS = %w[store retrieve].freeze
 global_opts = Trollop.options do
   opt :region, 'The region to look for the dynamodb in', default: 'us-east-1'
   banner 'utility for storing and retrieving encrypted values
@@ -55,5 +50,5 @@ when 'retrieve'
   result = keystore.retrieve key: cmd_opts[:keyname]
   puts result
 else
-  fail "unknown subcommand #{cmd}"
+  raise "unknown subcommand #{cmd}"
 end

--- a/circle.yml
+++ b/circle.yml
@@ -1,5 +1,0 @@
-machine:
-  timezone:
-    America/New_York
-  ruby:
-    version: 2.2.10

--- a/features/stepdefs/keystore_steps.rb
+++ b/features/stepdefs/keystore_steps.rb
@@ -12,18 +12,18 @@ end
 
 Given(/^a region to operate in$/) do
   @region = ENV['region']
-  fail if @region.nil?
+  raise if @region.nil?
 end
 
 Given(/^a KMS key id or KMS key alias to use$/) do
   @key_id = ENV['key_id']
   @key_alias = ENV['key_alias']
-  fail if @key_id.nil? and @key_alias.nil?
+  raise if @key_id.nil? && @key_alias.nil?
 end
 
 Given(/^a DynamoDB table to use$/) do
   @table_name = ENV['table_name']
-  fail if @table_name.nil?
+  raise if @table_name.nil?
 end
 
 When(/^I store a value in the keystore$/) do

--- a/keystore.gemspec
+++ b/keystore.gemspec
@@ -13,7 +13,7 @@ spec = Gem::Specification.new do |s|
   s.files       = ['lib/keystore.rb']
   s.require_paths << 'lib'
   s.require_paths << 'bin'
-  s.required_ruby_version = '>= 2.2'
+  s.required_ruby_version = '>= 2.5'
   s.add_runtime_dependency('aws-sdk-dynamodb')
   s.add_runtime_dependency('aws-sdk-kms')
   s.add_runtime_dependency('trollop', '~> 2')

--- a/keystore.gemspec
+++ b/keystore.gemspec
@@ -4,7 +4,7 @@ spec = Gem::Specification.new do |s|
   s.name          = 'keystore'
   s.executables  << 'keystore.rb'
   s.license       = 'MIT'
-  s.version       = '0.2.0'
+  s.version       = '0.3.0'
   s.author        = [ 'Jonny Sywulak', 'Stelligent' ]
   s.email         = 'jonny@stelligent.com'
   s.homepage      = 'http://www.stelligent.com'
@@ -14,8 +14,8 @@ spec = Gem::Specification.new do |s|
   s.require_paths << 'lib'
   s.require_paths << 'bin'
   s.required_ruby_version = '>= 2.2'
-  s.add_runtime_dependency('aws-sdk', '>= 2')
-  s.add_runtime_dependency('aws-sdk-core')
+  s.add_runtime_dependency('aws-sdk-dynamodb')
+  s.add_runtime_dependency('aws-sdk-kms')
   s.add_runtime_dependency('trollop', '~> 2')
   s.add_development_dependency('nyan-cat-formatter')
   s.add_development_dependency('cucumber')

--- a/keystore.gemspec
+++ b/keystore.gemspec
@@ -1,6 +1,4 @@
-require 'rake'
-
-spec = Gem::Specification.new do |s|
+Gem::Specification.new do |s|
   s.name          = 'keystore'
   s.executables  << 'keystore.rb'
   s.license       = 'MIT'

--- a/lib/keystore.rb
+++ b/lib/keystore.rb
@@ -2,18 +2,19 @@ require 'aws-sdk-dynamodb'
 require 'aws-sdk-kms'
 require 'base64'
 
-# utility to use AWS services to handle encryption and storage of secret data.
+# rubocop:disable Metrics/AbcSize
 class Keystore
   def initialize(params = {})
     @options = params
-    fail 'need to specify dynamo parameter' if @options[:dynamo].nil?
-    fail 'need to specify table_name parameter' if @options[:table_name].nil?
-    fail 'need to specify kms parameter' if @options[:kms].nil?
+    raise 'need to specify dynamo parameter' if @options[:dynamo].nil?
+    raise 'need to specify table_name parameter' if @options[:table_name].nil?
+    raise 'need to specify kms parameter' if @options[:kms].nil?
   end
 
   def store(params)
     # only need key id to encrypt, so check for it here
-    fail 'need to specify key_id or key_alias parameter' if @options[:key_id].nil? and @options[:key_alias].nil?
+    raise 'need to specify key_id or key_alias parameter' if @options[:key_id].nil? && @options[:key_alias].nil?
+
     key_id = @options[:key_id] || get_kms_keyid(@options[:key_alias])
 
     value_to_encrypt = params[:value].nil? || params[:value].empty? ? ' ' : params[:value]
@@ -27,8 +28,9 @@ class Keystore
 
   def retrieve(params)
     item = @options[:dynamo].get_item(table_name: @options[:table_name], key: { ParameterName: params[:key] }).item
-    fail KeyNotFoundError.new, "keyname #{params[:key]} not found" if item.nil?
-    fail KeyNotFoundError.new, "keyname #{params[:key]} not found" if item['Value'].nil?
+    raise KeyNotFoundError.new, "keyname #{params[:key]} not found" if item.nil?
+    raise KeyNotFoundError.new, "keyname #{params[:key]} not found" if item['Value'].nil?
+
     encoded_value = item['Value']
     encrypted_value = Base64.decode64(encoded_value)
     result = @options[:kms].decrypt(ciphertext_blob: encrypted_value).plaintext
@@ -36,14 +38,14 @@ class Keystore
   end
 
   private
+
   def get_kms_keyid(key_alias)
-    begin
-      @options[:kms].list_aliases.aliases.find { |resp| resp.alias_name == "alias/#{key_alias}" }.target_key_id
-    rescue NoMethodError
-      fail "#{key_alias} is not a valid kms key alias"
-    end
+    @options[:kms].list_aliases.aliases.find { |resp| resp.alias_name == "alias/#{key_alias}" }.target_key_id
+  rescue NoMethodError
+    raise "#{key_alias} is not a valid kms key alias"
   end
 end
+# rubocop:enable Metrics/AbcSize
 
 class KeyStoreError < StandardError
 end

--- a/lib/keystore.rb
+++ b/lib/keystore.rb
@@ -1,10 +1,5 @@
-require 'aws-sdk-core'
-begin
-  require 'aws-sdk-dynamodb'
-  require 'aws-sdk-kms'
-rescue LoadError
-  nil
-end
+require 'aws-sdk-dynamodb'
+require 'aws-sdk-kms'
 require 'base64'
 
 # utility to use AWS services to handle encryption and storage of secret data.

--- a/spec/keystore_spec.rb
+++ b/spec/keystore_spec.rb
@@ -17,6 +17,7 @@ class KMSResult
   end
 end
 
+# rubocop:disable Metrics/BlockLength
 RSpec.describe 'Keystore' do
   context 'it can store encrypted values' do
     it 'will call DynamoDB to store the value' do
@@ -129,7 +130,7 @@ RSpec.describe 'Keystore' do
 
       begin
         keystore.retrieve key: 'doesnotexist'
-        fail 'Keystore did not throw exception on invalid key'
+        raise 'Keystore did not throw exception on invalid key'
       rescue KeyNotFoundError => e
         # expected error
         puts e.message
@@ -137,3 +138,4 @@ RSpec.describe 'Keystore' do
     end
   end
 end
+# rubocop:enable Metrics/BlockLength


### PR DESCRIPTION
The `aws-sdk` gem pulls in 174 gems when we only need 2.